### PR TITLE
Added route end-to-end testing

### DIFF
--- a/cmd/infrared/main.go
+++ b/cmd/infrared/main.go
@@ -2,10 +2,11 @@ package main
 
 import (
 	"flag"
-	"github.com/haveachin/infrared"
 	"log"
 	"os"
 	"strconv"
+
+	"github.com/haveachin/infrared"
 )
 
 const (
@@ -101,4 +102,6 @@ func main() {
 	if err := gateway.ListenAndServe(proxies); err != nil {
 		log.Fatal("Gateway exited; error:", err)
 	}
+
+	gateway.KeepProcessActive()
 }

--- a/gateway.go
+++ b/gateway.go
@@ -2,10 +2,11 @@ package infrared
 
 import (
 	"errors"
-	"github.com/haveachin/infrared/callback"
-	"github.com/haveachin/infrared/protocol/handshaking"
 	"log"
 	"sync"
+
+	"github.com/haveachin/infrared/callback"
+	"github.com/haveachin/infrared/protocol/handshaking"
 )
 
 type Gateway struct {
@@ -30,8 +31,11 @@ func (gateway *Gateway) ListenAndServe(proxies []*Proxy) error {
 	}
 
 	log.Println("All proxies are online")
-	gateway.wg.Wait()
 	return nil
+}
+
+func (gateway *Gateway) KeepProcessActive() {
+	gateway.wg.Wait()
 }
 
 // Close closes all listeners
@@ -132,12 +136,12 @@ func (gateway *Gateway) listenAndServe(listener Listener, addr string) error {
 
 		go func() {
 			log.Printf("[>] Incoming %s on listener %s", conn.RemoteAddr(), addr)
+			defer conn.Close()
 			if err := gateway.serve(conn, addr); err != nil {
 				log.Printf("[x] %s closed connection with %s; error: %s", conn.RemoteAddr(), addr, err)
 				return
 			}
 			log.Printf("[x] %s closed connection with %s", conn.RemoteAddr(), addr)
-			conn.Close()
 		}()
 	}
 }


### PR DESCRIPTION
This should cover the basics of end to end route testing. There were some problems with the gateway not closing the connection with the client thats why I changed the `conn.Close()` into a `defer conn.Close()`. I also have changed the wg.Wait() to a separate different method so the tests will run even faster now. 

Also split up the config test which also was supposed to test the scenario in which the gateway receives a proxy protocol header, because if it fails we dont know or its bc of the config or bc of the proxy protocol header. 

Remove ~~and added~~ some more duplicated code. 

Oh and which formatter are you using? because when i format it keeps on moving the import packages, i believe im using the default one from go self. But it might be less annoying if we used to same for the project? 