### PR TITLE
Fix/forge&realip bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ More info on [Portainer](https://www.portainer.io/).
 
 ```json
 {
-  "domainName": "mc.example.com",
+  "domainNames": ["mc.example.com", "example.com"],
   "proxyTo": ":8080"
 }
 ```
@@ -152,7 +152,7 @@ More info on [Portainer](https://www.portainer.io/).
 
 ```json
 {
-  "domainName": "mc.example.com",
+  "domainNames": ["mc.example.com", "example.com"],
   "listenTo": ":25565",
   "proxyTo": ":8080",
   "proxyBind": "0.0.0.0",

--- a/config.go
+++ b/config.go
@@ -29,7 +29,7 @@ type ProxyConfig struct {
 	dialer         *Dialer
 	process        process.Process
 
-	DomainName        string               `json:"domainName"`
+	DomainNames       []string             `json:"domainNames"`
 	ListenTo          string               `json:"listenTo"`
 	ProxyTo           string               `json:"proxyTo"`
 	ProxyBind         string               `json:"proxyBind"`
@@ -180,7 +180,7 @@ type CallbackServerConfig struct {
 
 func DefaultProxyConfig() ProxyConfig {
 	return ProxyConfig{
-		DomainName:        "localhost",
+		DomainNames:       []string{"localhost"},
 		ListenTo:          ":25565",
 		Timeout:           1000,
 		DisconnectMessage: "Sorry {{username}}, but the server is offline.",

--- a/gateway.go
+++ b/gateway.go
@@ -133,9 +133,12 @@ func (gateway *Gateway) CloseProxy(proxyUID string) {
 
 func (gateway *Gateway) RegisterProxy(proxy *Proxy) error {
 	// Register new Proxy
+	uids := proxy.UIDs()
+	for _, uid := range uids {
+		log.Println("Registering proxy with UID", uid)
+		gateway.proxies.Store(uid, proxy)
+	}
 	proxyUID := proxy.UID()
-	log.Println("Registering proxy with UID", proxyUID)
-	gateway.proxies.Store(proxyUID, proxy)
 	proxiesActive.Inc()
 
 	proxy.Config.removeCallback = func() {

--- a/gateway_test.go
+++ b/gateway_test.go
@@ -61,9 +61,9 @@ func proxyConfigWithPortEnd(portEnd int) *ProxyConfig {
 
 func createBasicProxyConfig(serverDomain, gatewayAddr, serverAddr string) *ProxyConfig {
 	return &ProxyConfig{
-		DomainName: serverDomain,
-		ListenTo:   gatewayAddr,
-		ProxyTo:    serverAddr,
+		DomainNames: []string{serverDomain},
+		ListenTo:    gatewayAddr,
+		ProxyTo:     serverAddr,
 	}
 }
 
@@ -559,7 +559,7 @@ func TestRouting(t *testing.T) {
 		serverAddr := serverAddr(port)
 		proxyC.ListenTo = gatewayAddr(server.portEnd)
 		proxyC.ProxyTo = serverAddr
-		proxyC.DomainName = server.domain
+		proxyC.DomainNames = []string{server.domain}
 		routingConfig = append(routingConfig, proxyC)
 
 		serverC.id = server.id

--- a/protocol/handshaking/serverbound_handshake.go
+++ b/protocol/handshaking/serverbound_handshake.go
@@ -2,10 +2,11 @@ package handshaking
 
 import (
 	"fmt"
-	"github.com/haveachin/infrared/protocol"
 	"net"
 	"strings"
 	"time"
+
+	"github.com/haveachin/infrared/protocol"
 )
 
 const (
@@ -87,7 +88,7 @@ func (pk *ServerBoundHandshake) UpgradeToRealIP(clientAddr net.Addr, timestamp t
 	}
 
 	addr := string(pk.ServerAddress)
-	addrWithForge := strings.SplitAfter(addr, ForgeSeparator)
+	addrWithForge := strings.SplitN(addr, ForgeSeparator, 3)
 
 	addr = fmt.Sprintf("%s///%s///%d", addrWithForge[0], clientAddr.String(), timestamp.Unix())
 

--- a/proxy.go
+++ b/proxy.go
@@ -76,7 +76,7 @@ func (proxy *Proxy) Process() process.Process {
 func (proxy *Proxy) DomainName() string {
 	proxy.Config.RLock()
 	defer proxy.Config.RUnlock()
-	return proxy.Config.DomainName
+	return proxy.Config.DomainNames[0]
 }
 
 func (proxy *Proxy) ListenTo() string {

--- a/proxy.go
+++ b/proxy.go
@@ -73,6 +73,12 @@ func (proxy *Proxy) Process() process.Process {
 	return nil
 }
 
+func (proxy *Proxy) DomainNames() []string {
+	proxy.Config.RLock()
+	defer proxy.Config.RUnlock()
+	return proxy.Config.DomainNames
+}
+
 func (proxy *Proxy) DomainName() string {
 	proxy.Config.RLock()
 	defer proxy.Config.RUnlock()
@@ -156,6 +162,15 @@ func (proxy *Proxy) CallbackLogger() callback.Logger {
 
 func (proxy *Proxy) UID() string {
 	return proxyUID(proxy.DomainName(), proxy.ListenTo())
+}
+
+func (proxy *Proxy) UIDs() []string {
+	uids := []string{}
+	for _, domain := range(proxy.DomainNames()) {
+		uid := proxyUID(domain, proxy.ListenTo())
+		uids = append(uids, uid)
+	}
+	return uids
 }
 
 func (proxy *Proxy) addPlayer(conn Conn, username string) {


### PR DESCRIPTION
Not sure or we want to merge this one, but for anyway wondering how it happened or how to fix it. This will also be included on  refactor branch. 

Its the bug where the user had the ip of the server infrared is running on. This was because of incorrect splitting which left behind the `\x00` after the domain in the handshake and before the `///`, which RealIP/TCPShield plugin splitted which caused the problem to happen. 
