### PR TITLE
fix forge and realip incompatibility

### DIFF
--- a/protocol/handshaking/serverbound_handshake.go
+++ b/protocol/handshaking/serverbound_handshake.go
@@ -87,7 +87,7 @@ func (pk *ServerBoundHandshake) UpgradeToRealIP(clientAddr net.Addr, timestamp t
 	}
 
 	addr := string(pk.ServerAddress)
-	addrWithForge := strings.SplitAfter(addr, ForgeSeparator)
+	addrWithForge := strings.SplitN(addr, ForgeSeparator, 3)
 
 	addr = fmt.Sprintf("%s///%s///%d", addrWithForge[0], clientAddr.String(), timestamp.Unix())
 


### PR DESCRIPTION
Not sure or we want to merge this one, but for anyway wondering how it happened or how to fix it. This will also be included on  refactor branch. 

Its the bug where the user had the ip of the server infrared is running on. This was because of incorrect splitting which left behind the `\x00` after the domain in the handshake and before the `///`, which RealIP/TCPShield plugin splitted which caused the problem to happen. 
