### PR TITLE
Discord compliant webhook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 *.yaml
 
 .idea
+
+# common name of build output
+main

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,13 @@ WORKDIR /infrared/cmd/infrared
 ENV GO111MODULE=on
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a --installsuffix cgo -v -tags netgo -ldflags '-extldflags "-static"' -o /main .
 
+# Get valid certs for the go app to use in sending http requests
+FROM alpine AS ca-certs
+RUN apk --no-cache add ca-certificates
+
 FROM scratch
 LABEL maintainer="Hendrik Jonas Schlehlein <hendrik.schlehlein@gmail.com>"
+COPY --from=ca-certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 WORKDIR /
 COPY --from=builder /main ./
 ENTRYPOINT [ "./main" ]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,15 @@ More info on [Portainer](https://www.portainer.io/).
 |------------|--------|----------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | url        | String | true     |         | URL of the callback server URL.                                                                                                                                                                                                                                                         |
 | events     | Array  | true     |         | A string array of event names. Currently available event names are:<br>- `Error` will send error logs<br>- `PlayerJoin` will send player joins<br>- `PlayerLeave` will send player leaves<br>- `ContainerStart` will send container starts<br>- `ContainerStop` will send container stops |
+| discord    | Boolean| false    | false   | If the webhook url is a discord server, set to true to properly format request body.
+### Event Configuration
+| Field Name | Type | Required | Default | Description |
+|------------|------|----------|---------|-------------|
+|PlayerJoinConfig.Message     |String   | false  | `[{{eventType}}] [{{proxyUID}}] {{username}}` |  The message published to the provided webhook URL when a PlayerJoin Event Occurs. Currently available placeholders:<br>- `now` The time the event took place. <br>- `eventType` The type of event that occurred. <br>- `proxyUID` The id of the instance this event relates to. <br>- `username` The name of the user joining. <br>- `remoteAddress` The address of the user joining. <br>- `targetAddress` The address the user was proxied to.
+|PlayerLeaveConfig.Message    |String   | false  | `[{{eventType}}] [{{proxyUID}}] {{username}}` |  The message published to the provided webhook URL when a PlayerLeave Event Occurs. Currently available placeholders:<br>- `now` The time the event took place. <br>- `eventType` The type of event that occurred. <br>- `proxyUID` The id of the instance this event relates to. <br>- `username` The name of the user leaving. <br>- `remoteAddress` The address of the user joining. <br>- `targetAddress` The address the user was proxied to.
+|ContainerStopConfig.Message  |String   | false  | `[{{eventType}}] [{{proxyUID}}]` |  The message published to the provided webhook URL when a ContainerStop Event Occurs. Currently available placeholders:<br>- `now` The time the event took place.  <br>-`eventType` The type of event that occurred.  <br>- `proxyUID` The id of the instance this event relates to. 
+|ContainerStartConfig.Message |String   | false  | `[{{eventType}}] [{{proxyUID}}]` |  The message published to the provided webhook URL when a ContainerStart Event Occurs. Currently available placeholders:<br>- `now` The time the event took place.  <br>-`eventType` The type of event that occurred.  <br>- `proxyUID` The id of the instance this event relates to. 
+|ErrorConfig.Message          |String   | false  | `[{{eventType}}] [{{proxyUID}}] {{error}}` |  The message published to the provided webhook URL when a Error Event Occurs. Currently available placeholders:<br>- `now` The time the event took place.  <br>- `eventType` The type of event that occurred.  <br>- `proxyUID` The id of the instance this event relates to.  <br>- `error` The error that occured to fire this event
 
 
 ### Examples
@@ -204,7 +213,22 @@ More info on [Portainer](https://www.portainer.io/).
       "ContainerStart",
       "ContainerStop"
     ]
-  }
+  },
+  "PlayerJoin": {
+      "Message": "{{username}} has joined {{proxyUID}}."
+  },
+	"PlayerLeave": {
+      "Message": "{{username}} has left {{proxyUID}}."
+  },
+	"ContainerStop": {
+    "Message": "[{{proxyUID}}] Container has stopped."
+	},
+	"ContainerStart": {
+    "Message": "[{{proxyUID}}] Container has started."
+	},
+	"Error": {
+    "Message": "[{{eventType}}] [{{proxyUID}}] {{error}}"
+	}
 }
 ```
 

--- a/config.go
+++ b/config.go
@@ -42,6 +42,12 @@ type ProxyConfig struct {
 	OnlineStatus      StatusConfig         `json:"onlineStatus"`
 	OfflineStatus     StatusConfig         `json:"offlineStatus"`
 	CallbackServer    CallbackServerConfig `json:"callbackServer"`
+	PlayerJoin		  EventConfig	       `json:"PlayerJoinConfig"`
+	PlayerLeave		  EventConfig	       `json:"PlayerLeaveConfig"`
+	ContainerStop	  EventConfig          `json:"ContainerStopConfig"`
+	ContainerStart	  EventConfig          `json:"ContainerStartConfig"`
+	Error			  EventConfig	       `json:"ErrorConfig"`
+
 }
 
 func (cfg *ProxyConfig) Dialer() (*Dialer, error) {
@@ -183,6 +189,11 @@ func loadImageAndEncodeToBase64String(path string) (string, error) {
 type CallbackServerConfig struct {
 	URL    string   `json:"url"`
 	Events []string `json:"events"`
+	Discord bool `json:"Discord"`
+}
+
+type EventConfig struct {
+	Message string `json:"message"`
 }
 
 func DefaultProxyConfig() ProxyConfig {
@@ -200,6 +211,21 @@ func DefaultProxyConfig() ProxyConfig {
 			ProtocolNumber: 755,
 			MaxPlayers:     20,
 			MOTD:           "Powered by Infrared",
+		},
+		PlayerJoin: EventConfig{
+			Message: "[{{eventType}}] [{{proxyUID}}] {{username}}",
+		},
+		PlayerLeave: EventConfig{
+			Message: "[{{eventType}}] [{{proxyUID}}] {{username}}",
+		},
+		ContainerStop: EventConfig{
+			Message: "[{{eventType}}] [{{proxyUID}}]",
+		},
+		ContainerStart: EventConfig{
+			Message: "[{{eventType}}] [{{proxyUID}}]",
+		},
+		Error: EventConfig{
+			Message: "[{{eventType}}] [{{proxyUID}}] {{error}}",
 		},
 	}
 }

--- a/gateway.go
+++ b/gateway.go
@@ -217,6 +217,7 @@ func (gateway *Gateway) serve(conn Conn, addr string) error {
 		proxy.CallbackLogger().DispatchEvent(webhook.EventError{
 			Error:    err.Error(),
 			ProxyUID: proxyUID,
+			Message:	  proxy.EventErrorConfig().Message,
 		})
 		return err
 	}

--- a/webhook/event.go
+++ b/webhook/event.go
@@ -1,5 +1,9 @@
 package webhook
 
+import (
+	"time"
+)
+
 const (
 	EventTypeError          string = "Error"
 	EventTypePlayerJoin     string = "PlayerJoin"
@@ -10,15 +14,31 @@ const (
 
 type Event interface {
 	EventType() string
+	EventTemplate() map[string]string
+	EventBaseMessage() string
 }
 
 type EventError struct {
 	Error    string `json:"error"`
 	ProxyUID string `json:"proxyUid"`
+	Message string
 }
 
 func (event EventError) EventType() string {
 	return EventTypeError
+}
+
+func (event EventError) EventTemplate() map[string]string {
+	return map[string]string{
+		"now":       time.Now().Format(time.RFC822),
+		"eventType": event.EventType(),
+		"proxyUID":  event.ProxyUID,
+		"error":	 event.Error,
+	}
+}
+
+func (event EventError) EventBaseMessage() string {
+	return event.Message
 }
 
 type EventPlayerJoin struct {
@@ -26,10 +46,26 @@ type EventPlayerJoin struct {
 	RemoteAddress string `json:"remoteAddress"`
 	TargetAddress string `json:"targetAddress"`
 	ProxyUID      string `json:"proxyUid"`
+	Message string
 }
 
 func (event EventPlayerJoin) EventType() string {
 	return EventTypePlayerJoin
+}
+
+func (event EventPlayerJoin) EventTemplate() map[string]string {
+	return map[string]string{
+		"now":       time.Now().Format(time.RFC822),
+		"eventType": event.EventType(),
+		"proxyUID":  event.ProxyUID,
+		"username": event.Username,
+		"remoteAddress": event.RemoteAddress,
+		"targetAddress": event.TargetAddress,
+	}
+}
+
+func (event EventPlayerJoin) EventBaseMessage() string {
+	return event.Message
 }
 
 type EventPlayerLeave struct {
@@ -37,24 +73,66 @@ type EventPlayerLeave struct {
 	RemoteAddress string `json:"remoteAddress"`
 	TargetAddress string `json:"targetAddress"`
 	ProxyUID      string `json:"proxyUid"`
+	Message string
 }
 
 func (event EventPlayerLeave) EventType() string {
 	return EventTypePlayerLeave
 }
 
+func (event EventPlayerLeave) EventTemplate() map[string]string {
+	return map[string]string{
+		"now":       time.Now().Format(time.RFC822),
+		"eventType": event.EventType(),
+		"proxyUID":  event.ProxyUID,
+		"username": event.Username,
+		"remoteAddress": event.RemoteAddress,
+		"targetAddress": event.TargetAddress,
+	}
+}
+
+func (event EventPlayerLeave) EventBaseMessage() string {
+	return event.Message
+}
+
 type EventContainerStart struct {
 	ProxyUID string `json:"proxyUid"`
+	Message string
 }
 
 func (event EventContainerStart) EventType() string {
 	return EventTypeContainerStart
 }
 
+func (event EventContainerStart) EventTemplate() map[string]string {
+	return map[string]string{
+		"now":       time.Now().Format(time.RFC822),
+		"eventType": event.EventType(),
+		"proxyUID":  event.ProxyUID,
+	}
+}
+
+func (event EventContainerStart) EventBaseMessage() string {
+	return event.Message
+}
+
 type EventContainerStop struct {
 	ProxyUID string `json:"proxyUid"`
+	Message string
 }
 
 func (event EventContainerStop) EventType() string {
 	return EventTypeContainerStop
+}
+
+func (event EventContainerStop) EventTemplate() map[string]string {
+	return map[string]string{
+		"now":       time.Now().Format(time.RFC822),
+		"eventType": event.EventType(),
+		"proxyUID":  event.ProxyUID,
+	}
+}
+
+func (event EventContainerStop) EventBaseMessage() string {
+	return event.Message
 }

--- a/webhook/event_test.go
+++ b/webhook/event_test.go
@@ -3,38 +3,59 @@ package webhook_test
 import (
 	"github.com/haveachin/infrared/webhook"
 	"testing"
+
 )
 
 func TestErrorEvent_EventType(t *testing.T) {
 	tt := []struct {
 		event     webhook.Event
 		eventType string
+		eventString string
 	}{
 		{
-			event:     webhook.EventError{},
+			event:     webhook.EventError{
+				Message: "[{{eventType}}] [{{proxyUID}}] {{error}}",
+				Error: "Error Message",
+			},
 			eventType: webhook.EventTypeError,
+			eventString: "[" + webhook.EventTypeError + "] [] Error Message", 
 		},
 		{
-			event:     webhook.EventPlayerJoin{},
+			event:     webhook.EventPlayerJoin{
+				Message: "[{{eventType}}] [{{proxyUID}}] {{username}}",
+			},
 			eventType: webhook.EventTypePlayerJoin,
+			eventString: "[" + webhook.EventTypePlayerJoin + "] [] ",
 		},
 		{
-			event:     webhook.EventPlayerLeave{},
+			event:     webhook.EventPlayerLeave{
+				Message: "[{{eventType}}] [{{proxyUID}}] {{username}}",
+			},
 			eventType: webhook.EventTypePlayerLeave,
+			eventString: "[" + webhook.EventTypePlayerLeave + "] [] ",
 		},
 		{
-			event:     webhook.EventContainerStart{},
+			event:     webhook.EventContainerStart{
+				Message: "[{{eventType}}] [{{proxyUID}}]",
+			},
 			eventType: webhook.EventTypeContainerStart,
+			eventString: "[" + webhook.EventTypeContainerStart + "] []",
 		},
 		{
-			event:     webhook.EventContainerStop{},
+			event:     webhook.EventContainerStop{
+				Message: "[{{eventType}}] [{{proxyUID}}]",
+			},
 			eventType: webhook.EventTypeContainerStop,
+			eventString: "[" + webhook.EventTypeContainerStop + "] []",
 		},
 	}
 
 	for _, tc := range tt {
 		if tc.event.EventType() != tc.eventType {
 			t.Fail()
+		}
+		if webhook.EventString(tc.event) != tc.eventString {
+			t.Errorf("got %s, expected %s", webhook.EventString(tc.event), tc.eventString)
 		}
 	}
 }

--- a/webhook/webhook_test.go
+++ b/webhook/webhook_test.go
@@ -1,9 +1,9 @@
 package webhook_test
 
 import (
+	"github.com/haveachin/infrared/webhook"
 	"bytes"
 	"errors"
-	"github.com/haveachin/infrared/webhook"
 	"net/http"
 	"testing"
 )
@@ -64,6 +64,22 @@ func TestWebhook_DispatchEvent(t *testing.T) {
 			webhook: webhook.Webhook{
 				URL:        "https://example.com",
 				EventTypes: []string{webhook.EventTypePlayerJoin, webhook.EventTypePlayerLeave},
+			},
+			event: webhook.EventPlayerJoin{
+				Username:      "notch",
+				RemoteAddress: "1.2.3.4",
+				TargetAddress: "1.2.3.4",
+				ProxyUID:      "example.com@1.2.3.4:25565",
+			},
+			shouldDispatch:        true,
+			httpRequestShouldFail: false,
+		},
+		{
+			name: "WithDiscordWebhookTrue",
+			webhook: webhook.Webhook{
+				URL:        "https://example.com",
+				EventTypes: []string{webhook.EventTypePlayerJoin},
+				Discord: true,
 			},
 			event: webhook.EventPlayerJoin{
 				Username:      "notch",


### PR DESCRIPTION
I added some functionality to enable the previously named "callback" to work for discord webhooks. In this process, i added configurable event messages, similar to the "disconnectMessage" field. I originally based this addition on master, then found refactor was a bit different and probably the direction this project is going. Unfortunately, i seem to be having trouble getting "refactor" to function as a proxy at all for now. I had this tested and operational with the master branch though and added go tests. This is my first open source contribution ever, hopefully it can be of use!
![image](https://user-images.githubusercontent.com/43505013/128644240-703ce8ee-55b2-4a15-9a1a-936354b7512e.png)
