### PR TITLE
add link to similar project https://github.com/itzg/mc-router to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,7 @@ scrape_configs:
   * **Example response:** `infrared_proxies{instance="vps1.example.com:9070",job="infrared"} 5`
   * **instance:** what infrared instance has that amount of active proxies.
   * **job:** what job was specified in the prometheus configuration.
+
+## Similar Projects
+
+* https://github.com/itzg/mc-router


### PR DESCRIPTION
I don't know if you would consider linking to what appears to a project by @itzg in roughly the same space as yours? Even if you don't seem to serve exactly the same use case (if I understand what this project does correctly, see #15 for clarification), might still be of interest to other folks looking at this.