### PR TITLE
Added support for Minecraft 1.19.3

### DIFF
--- a/internal/pkg/java/protocol/login/serverbound_loginstart.go
+++ b/internal/pkg/java/protocol/login/serverbound_loginstart.go
@@ -58,7 +58,7 @@ func UnmarshalServerBoundLoginStart(packet protocol.Packet, version int32) (Serv
 		return pk, err
 	}
 
-	if version < protocol.Version_1_19 {
+	if version < protocol.Version_1_19 || version > protocol.Version_1_19_2 {
 		return pk, nil
 	}
 

--- a/internal/pkg/java/protocol/versions.go
+++ b/internal/pkg/java/protocol/versions.go
@@ -3,4 +3,5 @@ package protocol
 const (
 	Version_1_18_2 = 758
 	Version_1_19   = 759
+	Version_1_19_2 = 760
 )


### PR DESCRIPTION
Since Mojang changed the Login Start packet again in version 1.19.3, it is not possible to connect with this version in the current version of Infrared

# 1.19.2
![image](https://user-images.githubusercontent.com/26800520/208297489-da4907f4-8387-4c04-9b1c-8a209c013333.png)

# 1.19.3
![image](https://user-images.githubusercontent.com/26800520/208297508-76d9fa0c-31a4-4ee3-a1fd-27042a3d5e6b.png)
