### PR TITLE
Implement sending proxy protocol for login 

### DIFF
--- a/pkg/infrared/infrared.go
+++ b/pkg/infrared/infrared.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/haveachin/infrared/pkg/infrared/protocol"
+	"github.com/pires/go-proxyproto"
 )
 
 type Config struct {
@@ -191,6 +192,21 @@ func (ir *Infrared) handleLogin(c *conn, resp ServerRequestResponse) error {
 func (ir *Infrared) handlePipe(c *conn, resp ServerRequestResponse) error {
 	rc := resp.ServerConn
 	defer rc.ForceClose()
+
+	if resp.UseProxyProtocol {
+		header := &proxyproto.Header{
+			Version:           2,
+			Command:           proxyproto.PROXY,
+			TransportProtocol: proxyproto.TCPv4,
+			SourceAddr:        c.RemoteAddr(),
+			DestinationAddr:   rc.RemoteAddr(),
+		}
+
+		if _, err := header.WriteTo(rc); err != nil {
+			return err
+		}
+	}
+
 	if err := rc.WritePackets(c.readPks[0], c.readPks[1]); err != nil {
 		return err
 	}

--- a/pkg/infrared/infrared_test.go
+++ b/pkg/infrared/infrared_test.go
@@ -1,15 +1,18 @@
 package infrared
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"io"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/haveachin/infrared/pkg/infrared/protocol"
 	"github.com/haveachin/infrared/pkg/infrared/protocol/handshaking"
 	"github.com/haveachin/infrared/pkg/infrared/protocol/status"
+	"github.com/pires/go-proxyproto"
 )
 
 type mockServerRequestResponder struct {
@@ -104,4 +107,93 @@ func BenchmarkHandleConn_Status(b *testing.B) {
 		in.Close()
 		out.Close()
 	}
+}
+
+type ProxyProtocolTesterConn struct {
+	net.Conn
+	c net.Conn
+}
+
+func (c *ProxyProtocolTesterConn) RemoteAddr() net.Addr {
+	return &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 25565}
+}
+
+func (c *ProxyProtocolTesterConn) Read(b []byte) (int, error) {
+	return c.c.Read(b)
+}
+
+func (c *ProxyProtocolTesterConn) Write(b []byte) (int, error) {
+	return c.c.Write(b)
+}
+
+func (c *ProxyProtocolTesterConn) SetWriteDeadline(t time.Time) error {
+	return c.c.SetWriteDeadline(t)
+}
+
+func (c *ProxyProtocolTesterConn) SetReadDeadline(t time.Time) error {
+	return c.c.SetReadDeadline(t)
+}
+
+func TestProxyProtocolhandlePipe(t *testing.T) {
+	serverConnIn, serverConnOut := net.Pipe()
+	_, clientConnOut := net.Pipe()
+
+	clientConn := ProxyProtocolTesterConn{c: clientConnOut}
+
+	ir := New()
+
+	testConn := ProxyProtocolTesterConn{c: serverConnIn}
+
+	reqResponse := ServerRequestResponse{
+		ServerConn:       newConn(&testConn),
+		UseProxyProtocol: true,
+	}
+
+	go ir.handlePipe(newConn(&clientConn), reqResponse)
+
+	bufReader := bufio.NewReader(serverConnOut)
+	header, err := proxyproto.Read(bufReader)
+
+	if err != nil {
+		t.Fatalf("Unexpected error reading proxy protocol header: %v", err)
+	}
+
+	if header.Command != proxyproto.PROXY {
+		t.Fatalf("Unexpected proxy protocol command: %v", header.Command)
+	}
+
+	if header.TransportProtocol != proxyproto.TCPv4 {
+		t.Fatalf("Unexpected proxy protocol transport protocol: %v", header.TransportProtocol)
+	}
+
+	if header.Version != 2 {
+		t.Fatalf("Unexpected proxy protocol version: %v", header.Version)
+	}
+
+}
+
+func TestNoProxyProtocolhandlePipe(t *testing.T) {
+	serverConnIn, serverConnOut := net.Pipe()
+	_, clientConnOut := net.Pipe()
+
+	clientConn := ProxyProtocolTesterConn{c: clientConnOut}
+
+	ir := New()
+
+	testConn := ProxyProtocolTesterConn{c: serverConnIn}
+
+	reqResponse := ServerRequestResponse{
+		ServerConn:       newConn(&testConn),
+		UseProxyProtocol: false,
+	}
+
+	go ir.handlePipe(newConn(&clientConn), reqResponse)
+
+	bufReader := bufio.NewReader(serverConnOut)
+	_, err := proxyproto.Read(bufReader)
+
+	if err == nil {
+		t.Fatal("Expected error reading proxy protocol header, but got nothing")
+	}
+
 }

--- a/pkg/infrared/server.go
+++ b/pkg/infrared/server.go
@@ -89,9 +89,10 @@ type ServerRequest struct {
 }
 
 type ServerRequestResponse struct {
-	ServerConn     *conn
-	StatusResponse protocol.Packet
-	Err            error
+	ServerConn       *conn
+	StatusResponse   protocol.Packet
+	UseProxyProtocol bool
+	Err              error
 }
 
 type serverGateway struct {


### PR DESCRIPTION
#### Changes:
- For login requests, add the option for servers to enable proxy protocol to be used by piping the request from infrared to the minecraft server.   